### PR TITLE
Update pom.xml to change groovy version to avoid UnsupportedOperationException

### DIFF
--- a/portlet/juzu-portlet/pom.xml
+++ b/portlet/juzu-portlet/pom.xml
@@ -15,12 +15,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<dependency>
 			<groupId>org.juzu</groupId>
 			<artifactId>juzu-core</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.juzu</groupId>
 			<artifactId>juzu-plugins-servlet</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
upgrade version of juzu so that groovy 1.8.9 will be used to avoid: java.lang.UnsupportedOperationException: handle me gracefully