### PR TITLE
DOC-4197 Rename custom module definition

### DIFF
--- a/skinning/customizing-skin/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/skinning/customizing-skin/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -25,7 +25,7 @@
 
   <portal-skin>
     <skin-name>Default</skin-name>
-    <skin-module>CustomizedSkinModule</skin-module>
+    <skin-module>customModuleStyle</skin-module>
     <css-path>/skin/myStyle.css</css-path>
     <css-priority>1</css-priority>
   </portal-skin>


### PR DESCRIPTION
To make the custom module name having the top priority, the name should starts with "customModule"